### PR TITLE
Use fewer globals

### DIFF
--- a/models/form7600a.js
+++ b/models/form7600a.js
@@ -1,9 +1,10 @@
-// define collection
-Form7600A = new Mongo.Collection("form7600a");
+Form7600A = {};
 
-CreateForm7600A = function(formValues) {
+Form7600A.collection = new Mongo.Collection("form7600a");
+
+Form7600A.create = function(formValues) {
   // merge in default values
-  var mergedFormValues = _.extend(Form7600ADefaults, formValues)
+  var mergedFormValues = _.extend(Form7600A.defaults, formValues)
   
   // hacky timestamps
   var currentTime = new Date();
@@ -20,12 +21,12 @@ CreateForm7600A = function(formValues) {
   mergedFormValues['history'] = [];
 
   // returns the id
-  return Form7600A.insert(mergedFormValues);
+  return Form7600A.collection.insert(mergedFormValues);
 };
 
-UpdateForm7600A = function(id, formValues) {
+Form7600A.update = function(id, formValues) {
   // get current revision history
-  var form = Form7600A.findOne(id);  
+  var form = Form7600A.collection.findOne(id);  
   var historyGlob = form.history;
   
   // add the soon-to-be-outdated form to revision history
@@ -44,7 +45,7 @@ UpdateForm7600A = function(id, formValues) {
   });
 };
 
-Form7600ADefaults = {
+Form7600A.defaults = {
   'parties-requesting-agency-mailing-address-state': 'DC',
   'parties-requesting-agency-mailing-address-city': 'Washington',
   'parties-servicing-agency-name': 'General Services Administration',
@@ -59,10 +60,10 @@ Form7600ADefaults = {
 
 if (Meteor.isServer) {
   Meteor.publish("Form7600A", function () {
-    return Form7600A.find({owner: this.userId});
+    return Form7600A.collection.find({owner: this.userId});
   });
   
-  Form7600A.allow({
+  Form7600A.collection.allow({
     update: function(userId, doc, fields, modifier) {
       return doc.owner === userId;
     },
@@ -89,7 +90,11 @@ var merge = function(obj, key, value) {
   return copy;
 };
 
-Form7600AAttributes = [  
+/* 
+  Maps Mongo fields to field names expected by the iaa-gem.
+  (https://github.com/18f/iaa-gem) 
+*/
+Form7600A.attributes = [  
   {
     "parties-requesting-agency-mailing-address-state": "requesting_agency_address"
   },
@@ -305,8 +310,7 @@ Form7600AAttributes = [
   }
 ];
 
-
-Timestamps = {
+Form7600A.timestamps = {
   createdAt: {
     type: Date
   },
@@ -315,7 +319,7 @@ Timestamps = {
   }
 };
 
-Ownership = {
+Form7600A.ownership = {
   owner: {
     type: String,
     optional: false
@@ -325,7 +329,7 @@ Ownership = {
   }
 };
 
-Revisions = {
+Form7600A.revisions = {
   history: {
     type: [Object]
   }
@@ -333,22 +337,22 @@ Revisions = {
 
 var schemaHash = {};
 
-_.each(_.keys(Form7600AAttributes), function(attribute) {
+_.each(_.keys(Form7600A.attributes), function(attribute) {
   schemaHash[attribute] = { type: String };
 });
 
 _.extend(schemaHash, 
-  Timestamps, 
-  Ownership,
-  Revisions
+  Form7600A.timestamps, 
+  Form7600A.ownership,
+  Form7600A.revisions
 );
 
-Form7600ASchema = new SimpleSchema(schemaHash);
+Form7600A.Schema = new SimpleSchema(schemaHash);
 
-TransformForm7600AToPDFAttributes = function(form) {
+Form7600A.transformToPDFAttributes = function(form) {
   var result = {}
   
-  var noNulls = _.reject(Form7600AAttributes, function(obj) {
+  var noNulls = _.reject(Form7600A.attributes, function(obj) {
     return _.values(obj)[0] === null;
   });
   _.each(noNulls, function(obj) {
@@ -366,12 +370,10 @@ TransformForm7600AToPDFAttributes = function(form) {
     result = merge(result, value, mergeValue);
   });
   
-  console.log(result);
-  
   return result;
 };
 
-Render7600APDFFromBlob = function(blob, canvases) {
+Form7600A.renderPDFFromBlob = function(blob, canvases) {
   var url = URL.createObjectURL(blob);
   var viewerUrl = encodeURIComponent(url);
   PDFJS.workerSrc = '/packages/pascoual_pdfjs/build/pdf.worker.js';
@@ -383,7 +385,7 @@ Render7600APDFFromBlob = function(blob, canvases) {
 };
 
 if (Meteor.isClient) {
-  DownloadForm7600A = function(form) {
+  Form7600A.download = function(form) {
     
     var savePdf = function(pdf) {
       var blob = new Blob([pdf], {type: "application/pdf"});
@@ -392,9 +394,10 @@ if (Meteor.isClient) {
     
     var url = 'https://iaa-pdf-api.18f.gov/iaa/7600a';
     var options = {
-      data: TransformForm7600AToPDFAttributes(form),
+      data: Form7600A.transformToPDFAttributes(form),
       responseType: 'blob'
     };
+
     var callback = function(error, result) {
       if (!error) {
         savePdf(result.content);
@@ -406,4 +409,3 @@ if (Meteor.isClient) {
     HTTP.post(url, options, callback);
   };
 }
-

--- a/models/form7600a.js
+++ b/models/form7600a.js
@@ -40,7 +40,7 @@ Form7600A.update = function(id, formValues) {
   var currentTime = new Date();
   formValues['updatedAt'] = currentTime;
   
-  return Form7600A.update(id, {
+  return Form7600A.collection.update(id, {
     "$set": formValues
   });
 };

--- a/tests/mocha/server/models/form7600aTest.js
+++ b/tests/mocha/server/models/form7600aTest.js
@@ -33,7 +33,7 @@ if (!(typeof MochaWeb === 'undefined')) {
                         "parties-requesting-agency-mailing-address-zip" : requestingAgencyZip
                     };
 
-                    actual = TransformForm7600AToPDFAttributes(formData);
+                    actual = Form7600A.transformToPDFAttributes(formData);
                 });
                 
                 describe.skip("servicing_agency_name", function() {

--- a/views/form7600a/download/helpers.js
+++ b/views/form7600a/download/helpers.js
@@ -6,7 +6,7 @@ if (Meteor.isClient) {
     form: function() {
       var controller = Iron.controller();
       var formId = controller.state.get('formId');
-      var form = Form7600A.findOne(formId);
+      var form = Form7600A.collection.findOne(formId);
       
       return form;
     }

--- a/views/form7600a/download/rendered.js
+++ b/views/form7600a/download/rendered.js
@@ -3,9 +3,9 @@ if (Meteor.isClient) {
     Session.set('downloadPrompt', 'Your download will begin shortly.')
     var controller = Iron.controller();    
     var formId = controller.state.get('formId');   
-    var form = Form7600A.findOne({_id: formId});
+    var form = Form7600A.collection.findOne({_id: formId});
     
-    DownloadForm7600A(form);
+    Form7600A.download(form);
     Session.set('downloadPrompt', 'Your form has downloaded. You can refresh the page to download again.'); 
   });
 }

--- a/views/form7600a/events.js
+++ b/views/form7600a/events.js
@@ -6,7 +6,7 @@ if (Meteor.isClient) {
       var formValues = form.serializeJSON();
       var id = formValues.formId;
   
-      UpdateForm7600A(id, formValues);
+      Form7600A.update(id, formValues);
     }
   });
 }

--- a/views/form7600a/helpers.js
+++ b/views/form7600a/helpers.js
@@ -2,7 +2,7 @@ var isSelected = function(returnString) {
   return function(v1, v2) {
     var controller = Iron.controller();
     var formId = controller.state.get('formId');
-    var formValues = Form7600A.findOne(formId);
+    var formValues = Form7600A.collection.findOne(formId);
     if (formValues[v1] === v2) {
       return returnString;
     } else {
@@ -16,7 +16,7 @@ if (Meteor.isClient) {
     formValues: function() {
       var controller = Iron.controller();
       var formId = controller.state.get('formId');      
-      var form = Form7600A.findOne(formId);
+      var form = Form7600A.collection.findOne(formId);
             
       return form;
     },

--- a/views/form7600a/pdf/helpers.js
+++ b/views/form7600a/pdf/helpers.js
@@ -6,7 +6,7 @@ if (Meteor.isClient) {
     form: function() {
       var controller = Iron.controller();
       var formId = controller.state.get('formId');
-      var form = Form7600A.findOne(formId);
+      var form = Form7600A.collection.findOne(formId);
       
       return form;
     }

--- a/views/form7600a/pdf/rendered.js
+++ b/views/form7600a/pdf/rendered.js
@@ -5,11 +5,11 @@ if (Meteor.isClient) {
     self.autorun(function() {
       var controller = Iron.controller();    
       var formId = controller.state.get('formId');   
-      var form = Form7600A.findOne({_id: formId});
+      var form = Form7600A.collection.findOne({_id: formId});
     
       var url = 'https://iaa-pdf-api.18f.gov/iaa/7600a';
       var options = {
-        data: TransformForm7600AToPDFAttributes(form),
+        data: Form7600A.transformToPDFAttributes(form),
         responseType: 'blob'
       };
 
@@ -17,7 +17,7 @@ if (Meteor.isClient) {
         if (!error) {
           var blob = result.content;
           var canvases = ['pdfcanvas1', 'pdfcanvas2', 'pdfcanvas3', 'pdfcanvas4'];
-          Render7600APDFFromBlob(blob, canvases);
+          Form7600A.renderPDFFromBlob(blob, canvases);
         } else {
           alert('There was an error rendering the PDF: ' + error);
         }

--- a/views/index/events.js
+++ b/views/index/events.js
@@ -4,7 +4,7 @@ if (Meteor.isClient) {
       event.preventDefault();
       var form = $('.create-new-7600a-form');
       var formValues = form.serializeJSON();
-      var id = CreateForm7600A(formValues);
+      var id = Form7600A.create(formValues);
       
       form[0].reset();
       window.open('/7600a/' + id + '/edit');

--- a/views/index/helpers.js
+++ b/views/index/helpers.js
@@ -1,7 +1,7 @@
 if (Meteor.isClient) {
   Template.index.helpers({
     form7600as: function() {
-      return Form7600A.find();
+      return Form7600A.collection.find();
     },
     d: function(attr) {
       return this[attr];


### PR DESCRIPTION
I think this should be good to go (testing would be nice...).

This sticks all the global functions in `models/form7600a.js` behind the namespace `Form7600A` and updates all the callers accordingly.
